### PR TITLE
Added setup.py file to allow installing from github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+from distutils.core import setup
+
+setup(
+    name='PySteam',
+    version='0.1.dev',
+    packages=['steamapi', ],
+    license='MIT License',
+    description='Python interface for Steam web chat.',
+    #long_description=open('README.txt').read(),
+
+    classifiers=[
+        # https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'Development Status :: 3 - Alpha',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: MIT License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 3',
+    ],
+    install_requires=[
+        'requests',
+        'pycryptodome',
+        'pyee',
+        'enum34',
+        'pyquery',
+        'future',
+        'munch'
+    ],
+    extras_require={
+        'test':  ['pytest'],
+    },
+    keywords='steam web chat',
+)
+
+# Install in "editable mode" for development:
+# pip install -e .


### PR DESCRIPTION
Adding the following setup.py file will let others reuse your code directly from github by adding the github url to their `requirements.txt` files (and installing through pip):

`pip install git+https://github.com/russelg/PySteam`

This will install the `steamapi` package and also install all the requirements mentioned in README.md (requests, pycryptodome, etc...).

Running the following command:
`pip install git+https://github.com/russelg/PySteam#egg=PySteam[test]`
will also install `pytest`.

Tbh I'm not 100% sure if it's everything that is needed to push the repo to pypi, but for installing from github (which is what I need) it's enough. Feel free to enhance the file later.